### PR TITLE
chore: update deprecated next image config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['cdn.sanity.io'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'cdn.sanity.io',
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
fixing this warning: `The "images.domains" configuration is deprecated. Please use "images.remotePatterns" configuration instead.`