### PR TITLE
feat: update sanity components

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,6 +7,7 @@ import type { Footer as FooterProps } from '@/sanity/types/homepage'
 export const Footer = ({ content }: { content: FooterProps }) => {
   return (
     <footer className='text-light flex w-full flex-col items-center gap-6 pb-6 pt-8'>
+      {/* TODO: fix this to alternate between regular button and icon button */}
       <Link href={content.link.link}>{content.link.text}</Link>
       <Image
         src={urlForImage(content.logo).url()}
@@ -15,6 +16,7 @@ export const Footer = ({ content }: { content: FooterProps }) => {
         height={48}
         className='max-h-12'
       />
+      {/* TODO: fix this to alternate between regular button and icon button */}
       <Link
         href={content.copyright.link}
         className='px-4 pb-4 text-sm hover:underline'

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,17 +16,21 @@ export const Header = ({ content }: { content: HeaderProps }) => {
         </Button>
       </div>
       <div className='flex gap-2'>
-        {content.iconButtons.map(({ link, icon }) => (
-          <Button key={link} as={Link} href={link} variant='tertiary'>
-            <Image
-              src={urlForImage(icon).url()}
-              width={24}
-              height={24}
-              alt={icon.alt}
-              className='size-6 object-contain'
-            />
-          </Button>
-        ))}
+        {content.iconButtons.map(({ link, icon }) => {
+          // TODO: fix this to alternate between regular button and icon button
+          if (!icon) return null
+          return (
+            <Button key={link} as={Link} href={link} variant='tertiary'>
+              <Image
+                src={urlForImage(icon).url()}
+                width={24}
+                height={24}
+                alt={icon.alt}
+                className='size-6 object-contain'
+              />
+            </Button>
+          )
+        })}
       </div>
     </nav>
   )

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -12,7 +12,7 @@ export const Hero = ({ content }: { content: HeroProps }) => {
         backgroundImage: `url(${urlForImage(content.background_image).url()})`,
       }}
     >
-      {/* TODO: add ability to pick color and add icon in sanity */}
+      {/* TODO: fix this to alternate between regular button and icon button */}
       {content.ctas.map(({ _key, link, text }) => (
         <Button key={_key} as={Link} href={link}>
           {text}

--- a/components/JoinNow.tsx
+++ b/components/JoinNow.tsx
@@ -14,6 +14,7 @@ export const JoinNow = ({ content }: { content: NewsletterProps }) => {
         <div className='text-light max-w-xl text-center'>
           <PortableText value={content.desc} />
         </div>
+        {/* TODO: fix this to alternate between regular button and icon button */}
         <Button as={Link} href={content.button.link}>
           {content.button.text}
         </Button>

--- a/sanity/schemas/components/button.ts
+++ b/sanity/schemas/components/button.ts
@@ -1,15 +1,55 @@
 import { defineField, defineType } from 'sanity'
 
+import { assert } from '@/utils/assert'
+import { eitherOr } from '@/sanity/schemas/utils'
+
 export const button = defineType({
   name: 'button',
-  title: 'Call to action',
+  title: 'Button',
   type: 'object',
   fields: [
     defineField({
-      name: 'text',
-      title: 'Text',
+      name: 'label',
+      title: 'Label',
       type: 'string',
-      validation: (rule) => rule.required(),
+      validation: (rule) =>
+        rule.custom((field, context) =>
+          eitherOr(
+            () => {
+              assert(field)
+            },
+            () => {
+              assert(context.parent)
+              assert(typeof context.parent === 'object')
+              assert('icon' in context.parent)
+              assert(context.parent.icon)
+              assert(typeof context.parent.icon === 'object')
+              assert('asset' in context.parent.icon)
+            },
+            'Either label or icon needs to be defined',
+          ),
+        ),
+    }),
+    defineField({
+      name: 'icon',
+      title: 'Icon',
+      type: 'svg_with_alt',
+      validation: (rule) =>
+        rule.custom((field, context) =>
+          eitherOr(
+            () => {
+              assert(field)
+              assert(typeof field === 'object')
+              assert('asset' in field)
+            },
+            () => {
+              assert(context.parent)
+              assert(typeof context.parent === 'object')
+              assert('label' in context.parent)
+            },
+            'Either label or icon needs to be defined',
+          ),
+        ),
     }),
     defineField({
       name: 'link',

--- a/sanity/schemas/components/image.ts
+++ b/sanity/schemas/components/image.ts
@@ -1,0 +1,30 @@
+import { defineField, defineType } from 'sanity'
+
+export const imageWithAlt = defineType({
+  name: 'image_with_alt',
+  title: 'Image',
+  type: 'image',
+  fields: [
+    defineField({
+      name: 'alt',
+      title: 'Alternative text',
+      type: 'string',
+    }),
+  ],
+})
+
+export const svgWithAlt = defineType({
+  name: 'svg_with_alt',
+  title: 'Svg',
+  type: 'image',
+  options: {
+    accept: '.svg',
+  },
+  fields: [
+    defineField({
+      name: 'alt',
+      title: 'Alternative text',
+      type: 'string',
+    }),
+  ],
+})

--- a/sanity/schemas/homepage.ts
+++ b/sanity/schemas/homepage.ts
@@ -6,15 +6,15 @@ export const homepage = defineType({
   type: 'document',
   fields: [
     defineField({
-      name: 'hero',
-      title: 'Hero section',
-      type: 'hero_section',
-      validation: (rule) => rule.required(),
-    }),
-    defineField({
       name: 'header',
       title: 'Header Section',
       type: 'header_section',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'hero',
+      title: 'Hero section',
+      type: 'hero_section',
       validation: (rule) => rule.required(),
     }),
     defineField({

--- a/sanity/schemas/index.ts
+++ b/sanity/schemas/index.ts
@@ -1,4 +1,5 @@
 import { homepage } from './homepage'
+import { header } from './sections/header'
 import { hero } from './sections/hero'
 import { trailer } from './sections/trailer'
 import { description } from './sections/description'
@@ -6,16 +7,18 @@ import { character } from './sections/character'
 import { newsletter } from './sections/newsletter'
 import { footer } from './sections/footer'
 import { button } from './components/button'
-import { header } from './sections/header'
+import { imageWithAlt, svgWithAlt } from './components/image'
 
 export const schema = [
   homepage,
-  hero,
   header,
+  hero,
   trailer,
   description,
   character,
   newsletter,
   footer,
   button,
+  imageWithAlt,
+  svgWithAlt,
 ]

--- a/sanity/schemas/sections/character.ts
+++ b/sanity/schemas/sections/character.ts
@@ -1,4 +1,4 @@
-import { defineArrayMember, defineField, defineType } from 'sanity'
+import { defineField, defineType } from 'sanity'
 
 export const character = defineType({
   name: 'character_section',

--- a/sanity/schemas/sections/description.ts
+++ b/sanity/schemas/sections/description.ts
@@ -33,14 +33,7 @@ export const description = defineType({
             defineField({
               name: 'image',
               title: 'Image',
-              type: 'image',
-              fields: [
-                defineField({
-                  name: 'alt',
-                  title: 'Alternative text',
-                  type: 'string',
-                }),
-              ],
+              type: 'image_with_alt',
               validation: (rule) => rule.required(),
             }),
             defineField({

--- a/sanity/schemas/sections/footer.ts
+++ b/sanity/schemas/sections/footer.ts
@@ -16,10 +16,7 @@ export const footer = defineType({
       name: 'logo',
       title: 'Logo',
       description: 'Upload the logo as an .svg file',
-      type: 'image',
-      options: {
-        accept: '.svg',
-      },
+      type: 'svg_with_alt',
       validation: (rule) => rule.required(),
     }),
     defineField({

--- a/sanity/schemas/sections/header.ts
+++ b/sanity/schemas/sections/header.ts
@@ -14,33 +14,7 @@ export const header = defineType({
         defineArrayMember({
           name: 'button',
           title: 'Button',
-          type: 'object',
-          validation: (rule) => rule.required(),
-          fields: [
-            defineField({
-              name: 'icon',
-              title: 'Icon',
-              type: 'image',
-              options: {
-                accept: '.svg',
-              },
-              fields: [
-                defineField({
-                  name: 'alt',
-                  title: 'Alternative text',
-                  type: 'string',
-                }),
-              ],
-              validation: (rule) => rule.required(),
-            }),
-            defineField({
-              name: 'link',
-              title: 'Link',
-              type: 'url',
-              validation: (rule) =>
-                rule.required().uri({ allowRelative: true }),
-            }),
-          ],
+          type: 'button',
         }),
       ],
     }),

--- a/sanity/schemas/utils.ts
+++ b/sanity/schemas/utils.ts
@@ -1,0 +1,35 @@
+/**
+ * validation to make sure at least one of two conditions are met
+ *
+ * @param either first condition. if the function throws an `Error`, the condition is considered invalid
+ * @param or second condition. if the function throws an `Error`, the condition is considered invalid
+ * @param message error message
+ *
+ * @example
+ * ```ts
+ * import { assert } from '@/utils/assert'
+ *
+ * eitherOr(
+ *  () => assert(true),
+ *  () => assert(false),
+ *  'this error will never be returned'
+ * )
+ * ```
+ */
+export const eitherOr = (
+  either: () => void,
+  or: () => void,
+  message: string,
+): true | string => {
+  try {
+    either()
+    return true
+  } catch {
+    try {
+      or()
+      return true
+    } catch {
+      return message
+    }
+  }
+}

--- a/sanity/types/homepage.ts
+++ b/sanity/types/homepage.ts
@@ -10,8 +10,9 @@ export type Homepage = {
   footer: Footer | undefined
 }
 
-export type Cta = {
-  text: string
+export type Button = {
+  text?: string
+  icon?: ImageWithAlt
   link: string
   _key: string
 }
@@ -21,15 +22,12 @@ interface ImageWithAlt extends Image {
 }
 
 export type Header = {
-  iconButtons: {
-    icon: ImageWithAlt
-    link: string
-  }[]
+  iconButtons: Button[]
 }
 
 export type Hero = {
   background_image: Image
-  ctas: Cta[]
+  ctas: Button[]
 }
 
 export type Trailer = {
@@ -56,11 +54,11 @@ export type Character = {
 export type Newsletter = {
   title: string
   desc: PortableTextBlock
-  button: Cta
+  button: Button
 }
 
 export type Footer = {
-  link: Cta
+  link: Button
   logo: Image
-  copyright: Cta
+  copyright: Button
 }

--- a/utils/assert.ts
+++ b/utils/assert.ts
@@ -1,0 +1,11 @@
+const prefix = 'Assertion failed'
+
+export function assert(
+  condition: unknown,
+  message?: string,
+): asserts condition {
+  if (condition) return
+
+  const error = message ? `${prefix}: ${message}` : prefix
+  throw new Error(error)
+}


### PR DESCRIPTION
- update button schema to have at least an icon or text
  - create `assert` function
  - create `eitherOr` helper for this type of sanity validation
- create image schemas for any image with alt and svg with alt
- update places where these are used
- add todo comments to update buttons