### PR TITLE
fix: cache homepage for 15 min

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,11 @@ import { Footer } from '@/components/Footer'
 import type { Homepage } from '@/sanity/schemas/homepage'
 
 const getHomepage = async () => {
-  return await client.fetch(`*[_type == "homepage"][0]`)
+  return await client.fetch(
+    `*[_type == "homepage"][0]`,
+    {},
+    { next: { revalidate: 60 * 15 } }, // cache for 15 minutes
+  )
 }
 
 export default async function Home() {


### PR DESCRIPTION
next automatically caches all fetch requests for a long time. this makes it revalidate the data every 15 minutes